### PR TITLE
fix(mobile): quiz entry screen bb-80

### DIFF
--- a/apps/mobile/src/screens/quiz-entry/quiz-entry.tsx
+++ b/apps/mobile/src/screens/quiz-entry/quiz-entry.tsx
@@ -45,7 +45,7 @@ const QuizEntry: React.FC = () => {
 					/>
 					<Text
 						preset="subheading"
-						style={[globalStyles.pb12, styles.text]}
+						style={[globalStyles.pb12, globalStyles.ph12, styles.text]}
 						weight="bold"
 					>
 						Answer a few questions to find out which areas of your life are


### PR DESCRIPTION
Related Issue: 80 - feat: Quiz Entry screen

Description: This pull request addresses the padding inconsistencies on the Quiz Entry screen as reported during the testing phase. The paddings on the emulator differed from the mockups provided in Figma. These changes align the paddings on the screen with the design specifications, ensuring a consistent user interface across all devices.

Changes Include:

Adjusted paddings to match the mockup in Figma.
Verified the layout on multiple screen sizes to ensure consistent appearance.
Updated screenshots to reflect the corrected layout.
Screenshots:

<img width="306" alt="Знімок екрана 2024-08-29 о 21 20 02" src="https://github.com/user-attachments/assets/0e77c4a9-54b2-4a6b-a752-f6d50f122077">

The fix ensures that the UI is consistent with the design guidelines provided in Figma, enhancing the overall user experience.