### PR TITLE
fix(frontend): evened out header with sidebar logo bb-252

### DIFF
--- a/apps/frontend/src/libs/components/sidebar/styles.module.css
+++ b/apps/frontend/src/libs/components/sidebar/styles.module.css
@@ -15,9 +15,7 @@
 }
 
 .logo-container {
-	padding-top: 24px;
-	padding-bottom: 25px;
-	padding-left: 40px;
+	padding: 17px 0 17px 40px;
 	font-size: 28px;
 	font-weight: 800;
 	border-bottom: 1px solid var(--white);

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 			}
 		},
 		"apps/backend": {
-			"version": "1.8.0",
+			"version": "1.9.0",
 			"dependencies": {
 				"@fastify/static": "7.0.4",
 				"@fastify/swagger": "8.15.0",
@@ -86,7 +86,7 @@
 			}
 		},
 		"apps/frontend": {
-			"version": "1.17.1",
+			"version": "1.19.0",
 			"dependencies": {
 				"@hookform/resolvers": "3.9.0",
 				"@reduxjs/toolkit": "2.2.7",
@@ -21007,7 +21007,7 @@
 			}
 		},
 		"packages/shared": {
-			"version": "1.7.0",
+			"version": "1.8.0",
 			"devDependencies": {
 				"zod": "3.23.8"
 			},


### PR DESCRIPTION
### Summary

Sidebar logo is now on the same level with header component
<img width="1440" alt="Screenshot 2024-09-02 at 15 24 38" src="https://github.com/user-attachments/assets/5e9c0473-69c8-44cd-a3c6-5686d7705fa1">
