### PR TITLE
feat(frontend): quiz question screen mobile responsiveness bb-290

### DIFF
--- a/apps/frontend/src/libs/components/input/styles.module.css
+++ b/apps/frontend/src/libs/components/input/styles.module.css
@@ -96,4 +96,13 @@
 		font-weight: 700;
 		line-height: 25px;
 	}
+
+	.radio-field {
+		display: none;
+	}
+
+	.radio-option {
+		justify-content: center;
+		width: 100%;
+	}
 }

--- a/apps/frontend/src/libs/components/input/styles.module.css
+++ b/apps/frontend/src/libs/components/input/styles.module.css
@@ -38,7 +38,7 @@
 .radio-label {
 	font-size: 20px;
 	font-weight: 700;
-	line-height: 1.4;
+	line-height: 28px;
 }
 
 .radio-option {
@@ -88,4 +88,12 @@
 	background-color: var(--white);
 	border-radius: 50%;
 	transform: translate(-50%, -50%);
+}
+
+@media (width <= 768px) {
+	.radio-label {
+		font-size: 16px;
+		font-weight: 700;
+		line-height: 25px;
+	}
 }

--- a/apps/frontend/src/libs/components/quiz-question/styles.module.css
+++ b/apps/frontend/src/libs/components/quiz-question/styles.module.css
@@ -3,8 +3,8 @@
 }
 
 .quiz-question:not(:last-of-type) {
-	padding-bottom: 40px;
-	margin-bottom: 40px;
+	padding-bottom: 30px;
+	margin-bottom: 30px;
 }
 
 .quiz-question:not(:last-of-type)::after {

--- a/apps/frontend/src/pages/quiz/libs/components/quiz-form/quiz-form.tsx
+++ b/apps/frontend/src/pages/quiz/libs/components/quiz-form/quiz-form.tsx
@@ -1,3 +1,5 @@
+import RippleEffectBg from "~/assets/img/ripple-effect-bg.svg?react";
+import RippleEffectBg2 from "~/assets/img/ripple-effect-bg2.svg?react";
 import {
 	Button,
 	Loader,
@@ -78,10 +80,12 @@ const QuizForm: React.FC<Properties> = ({ onNext }: Properties) => {
 	return (
 		<div className={styles["quiz-container"]}>
 			<form className={styles["questions-form"]} onSubmit={handleFormSubmit}>
-				<ProgressBar
-					currentStep={currentCategoryIndex}
-					numberOfSteps={questions.length}
-				/>
+				<div className={styles["progress-bar-container"]}>
+					<ProgressBar
+						currentStep={currentCategoryIndex}
+						numberOfSteps={questions.length}
+					/>
+				</div>
 				<h2 className={styles["quiz-header"]}>Wheel Quiz questions</h2>
 				<div className={styles["questions-wrapper"]}>
 					{isLoading ? (
@@ -124,6 +128,10 @@ const QuizForm: React.FC<Properties> = ({ onNext }: Properties) => {
 					)}
 				</div>
 			</form>
+			<RippleEffectBg className={styles["ripple-effect__background1"]} />
+			<RippleEffectBg2 className={styles["ripple-effect__background2"]} />
+			<div className={styles["circle-gradient1"]} />
+			<div className={styles["circle-gradient2"]} />
 		</div>
 	);
 };

--- a/apps/frontend/src/pages/quiz/libs/components/quiz-form/styles.module.css
+++ b/apps/frontend/src/pages/quiz/libs/components/quiz-form/styles.module.css
@@ -1,11 +1,14 @@
 .quiz-container {
+	position: relative;
 	display: flex;
 	min-height: 100vh;
 	padding: 34px;
+	overflow: hidden;
 	background-color: var(--background);
 }
 
 .questions-form {
+	z-index: var(--z-index-high);
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -14,6 +17,10 @@
 	padding: 41px;
 	background-color: white;
 	border-radius: 30px;
+}
+
+.progress-bar-container {
+	display: contents;
 }
 
 .quiz-header {
@@ -37,4 +44,73 @@
 
 .isVisible {
 	display: block;
+}
+
+.ripple-effect__background1,
+.ripple-effect__background2 {
+	display: none;
+}
+
+@media (width <= 768px) {
+	.quiz-container {
+		padding: 50px 15px 25px;
+	}
+
+	.progress-bar-container {
+		display: none;
+	}
+
+	.quiz-header {
+		font-size: 20px;
+	}
+
+	.ripple-effect__background1,
+	.ripple-effect__background2 {
+		position: absolute;
+		z-index: var(--z-index-low);
+		display: block;
+		width: 528px;
+		height: 528px;
+	}
+
+	.ripple-effect__background1 {
+		top: -131px;
+		left: 109px;
+		z-index: var(--z-index-medium);
+	}
+
+	.ripple-effect__background2 {
+		bottom: -291px;
+		left: -136px;
+	}
+
+	.circle-gradient1 {
+		position: absolute;
+		bottom: -39px;
+		left: -37px;
+		z-index: var(--z-index-medium);
+		width: 148px;
+		height: 148px;
+		background: linear-gradient(
+			to right,
+			var(--free-time-start) 0%,
+			var(--free-time-end) 100%
+		);
+		border-radius: 50%;
+	}
+
+	.circle-gradient2 {
+		position: absolute;
+		top: -17px;
+		left: 191px;
+		z-index: var(--z-index-low);
+		width: 86px;
+		height: 86px;
+		background: linear-gradient(
+			to right,
+			var(--mental-start) 0%,
+			var(--mental-end) 100%
+		);
+		border-radius: 50%;
+	}
 }

--- a/apps/frontend/src/pages/quiz/libs/components/quiz-form/styles.module.css
+++ b/apps/frontend/src/pages/quiz/libs/components/quiz-form/styles.module.css
@@ -11,10 +11,11 @@
 	z-index: var(--z-index-high);
 	display: flex;
 	flex-direction: column;
+	gap: 40px;
 	align-items: center;
 	justify-content: space-between;
 	width: 100%;
-	padding: 41px;
+	padding: 30px 20px 40px;
 	background-color: white;
 	border-radius: 30px;
 }


### PR DESCRIPTION
## Summary
Added mobile responsiveness for quiz question screen.
## Updated
- quiz-form.tsx: added background ripple effect and gradient circles for mobile version of page.
- styles for quiz form, quiz question and input.
## Screen record
 
![quiz-question-screen-mobile-responsiveness](https://github.com/user-attachments/assets/c92291f2-6c2b-4158-976c-7818ef8ab40d)
