### PR TITLE
fix(mobile): rename placeholder for email bb-210

### DIFF
--- a/apps/mobile/src/screens/auth/components/sign-in-form/sign-in-form.tsx
+++ b/apps/mobile/src/screens/auth/components/sign-in-form/sign-in-form.tsx
@@ -53,7 +53,7 @@ const SignInForm: React.FC<Properties> = ({ onSubmit }) => {
 				errors={errors}
 				label="Email"
 				name="email"
-				placeholder="be@balance.com"
+				placeholder="name@example.com"
 			/>
 			<Input
 				accessoryRight={

--- a/apps/mobile/src/screens/auth/components/sign-up-form/sign-up-form.tsx
+++ b/apps/mobile/src/screens/auth/components/sign-up-form/sign-up-form.tsx
@@ -82,7 +82,7 @@ const SignUpForm: React.FC<Properties> = ({ onSubmit }) => {
 				errors={errors}
 				label="Email"
 				name="email"
-				placeholder="be@balance.com"
+				placeholder="name@example.com"
 			/>
 			<Input
 				accessoryRight={


### PR DESCRIPTION
Change email placeholder to "name@example.com" for sign-in, sign-up forms