### PR TITLE
fix(frontend): update font-size for forgot password link on sign in page bb-331

### DIFF
--- a/apps/frontend/src/pages/auth/libs/components/sign-in-form/styles.module.css
+++ b/apps/frontend/src/pages/auth/libs/components/sign-in-form/styles.module.css
@@ -8,6 +8,7 @@
 
 .forgot-password-container {
 	align-self: center;
+	font-size: 16px;
 }
 
 .circle-gradient1 {


### PR DESCRIPTION
## Summary
Updated font-size for forgot password link on sign in page.
## Screenshot
![image](https://github.com/user-attachments/assets/e6ab3f78-39dd-45f1-8f04-21cc6ec577a7)
