### PR TITLE
fix(frontend): missing font-weight property for active sidebar button bb-432

### DIFF
--- a/apps/frontend/src/libs/components/link/styles.module.css
+++ b/apps/frontend/src/libs/components/link/styles.module.css
@@ -39,6 +39,7 @@
 }
 
 .navLink-active {
+	font-weight: 700;
 	background-color: var(--white);
 }
 


### PR DESCRIPTION
#432 
#### Preview

https://github.com/user-attachments/assets/051bbd11-95ef-4c57-b13e-a282bead8736

