### PR TITLE
chore(frontend): adjust quiz intro button label bb-426

### DIFF
--- a/apps/frontend/src/pages/quiz/libs/components/introduction/introduction.tsx
+++ b/apps/frontend/src/pages/quiz/libs/components/introduction/introduction.tsx
@@ -22,7 +22,7 @@ const Introduction: React.FC<Properties> = ({ onNext }: Properties) => {
 					outstanding and which areas you are missing out on
 				</p>
 				<div className={styles["btn"]}>
-					<Button label="CONTINUE" onClick={onNext} type="button" />
+					<Button label="START" onClick={onNext} type="button" />
 				</div>
 			</div>
 			<RippleEffectBg className={styles["ripple-effect__background1"]} />


### PR DESCRIPTION
Regarding issue #426, this PR will change the Quiz Introduction Screen Button Label based on the issue requirement.

## Screenshots

![Screenshot (394)](https://github.com/user-attachments/assets/d7b2757b-c318-4318-b168-8b7330cf29c5)
