### PR TITLE
fix(frontend): add missing `/profile` navigation on header bb-464

### DIFF
--- a/apps/frontend/src/libs/components/header/header.tsx
+++ b/apps/frontend/src/libs/components/header/header.tsx
@@ -1,8 +1,8 @@
-import defaultAvatar from "~/assets/img/default-avatar.png";
 import { Button } from "~/libs/components/components.js";
 import { useAppSelector } from "~/libs/hooks/hooks.js";
 import { type UserDto } from "~/modules/users/users.js";
 
+import { HeaderUserInfo } from "./libs/components/components.js";
 import styles from "./styles.module.css";
 
 type Properties = {
@@ -25,14 +25,7 @@ const Header: React.FC<Properties> = ({ onSidebarToggle }: Properties) => {
 				/>
 			</div>
 
-			<div className={styles["user-info"]}>
-				<img
-					alt={`${user.name}'s avatar`}
-					className={styles["user-avatar"]}
-					src={user.avatarUrl ?? defaultAvatar}
-				/>
-				<span className={styles["user-name"]}>{user.name}</span>
-			</div>
+			<HeaderUserInfo user={user} />
 		</header>
 	);
 };

--- a/apps/frontend/src/libs/components/header/libs/components/components.ts
+++ b/apps/frontend/src/libs/components/header/libs/components/components.ts
@@ -1,0 +1,1 @@
+export { HeaderUserInfo } from "./header-user-info/header-user-info.jsx";

--- a/apps/frontend/src/libs/components/header/libs/components/header-user-info/header-user-info.tsx
+++ b/apps/frontend/src/libs/components/header/libs/components/header-user-info/header-user-info.tsx
@@ -1,0 +1,32 @@
+import defaultAvatar from "~/assets/img/default-avatar.png";
+import { AppRoute } from "~/libs/enums/enums.js";
+import { useAppNavigate, useCallback } from "~/libs/hooks/hooks.js";
+import { type UserDto } from "~/modules/users/users.js";
+
+import styles from "./styles.module.css";
+
+type Properties = {
+	user: UserDto;
+};
+
+const HeaderUserInfo: React.FC<Properties> = ({ user }: Properties) => {
+	const navigate = useAppNavigate();
+
+	const handleClick = useCallback(() => {
+		navigate(AppRoute.PROFILE);
+	}, [navigate]);
+
+	return (
+		<label className={styles["container"]}>
+			<input className="visually-hidden" onClick={handleClick} type="button" />
+			<img
+				alt={`${user.name}'s avatar`}
+				className={styles["avatar"]}
+				src={user.avatarUrl ?? defaultAvatar}
+			/>
+			<span className={styles["username"]}>{user.name}</span>
+		</label>
+	);
+};
+
+export { HeaderUserInfo };

--- a/apps/frontend/src/libs/components/header/libs/components/header-user-info/styles.module.css
+++ b/apps/frontend/src/libs/components/header/libs/components/header-user-info/styles.module.css
@@ -1,0 +1,29 @@
+.container {
+	display: flex;
+	align-items: center;
+	margin-top: 13px;
+	margin-bottom: 17px;
+	cursor: pointer;
+}
+
+.avatar {
+	width: 47px;
+	height: 47px;
+	margin-right: 9px;
+	object-fit: cover;
+	border-radius: 50%;
+}
+
+.username {
+	padding-right: 4px;
+	font-size: 16px;
+	font-weight: 600;
+	line-height: 24px;
+	color: var(--black);
+}
+
+@media screen and (width <= 768px) {
+	.username {
+		display: none;
+	}
+}

--- a/apps/frontend/src/libs/components/header/styles.module.css
+++ b/apps/frontend/src/libs/components/header/styles.module.css
@@ -16,34 +16,7 @@
 	display: none;
 }
 
-.user-info {
-	display: flex;
-	align-items: center;
-	margin-top: 13px;
-	margin-bottom: 17px;
-}
-
-.user-avatar {
-	width: 47px;
-	height: 47px;
-	margin-right: 9px;
-	object-fit: cover;
-	border-radius: 50%;
-}
-
-.user-name {
-	padding-right: 4px;
-	font-size: 16px;
-	font-weight: 600;
-	line-height: 24px;
-	color: var(--black);
-}
-
 @media screen and (width <= 768px) {
-	.user-name {
-		display: none;
-	}
-
 	.header {
 		justify-content: space-between;
 		padding-inline: 15px;

--- a/apps/frontend/src/libs/hooks/hooks.ts
+++ b/apps/frontend/src/libs/hooks/hooks.ts
@@ -1,5 +1,6 @@
 export { useAppDispatch } from "./use-app-dispatch/use-app-dispatch.hook.js";
 export { useAppForm } from "./use-app-form/use-app-form.hook.js";
+export { useAppNavigate } from "./use-app-navigate/use-app-navigate.hook.js";
 export { useAppSelector } from "./use-app-selector/use-app-selector.hook.js";
 export { useQuery } from "./use-query/use-query-hook.js";
 export { useCallback, useEffect, useRef, useState } from "react";

--- a/apps/frontend/src/libs/hooks/use-app-navigate/use-app-navigate.hook.ts
+++ b/apps/frontend/src/libs/hooks/use-app-navigate/use-app-navigate.hook.ts
@@ -1,0 +1,1 @@
+export { useNavigate as useAppNavigate } from "react-router-dom";


### PR DESCRIPTION
Related to issue #464, this PR will add missing navigation on Header Profile component.

[recording.webm](https://github.com/user-attachments/assets/5980bdd5-977f-40dd-9249-f3fa5deb8299)
