### PR TITLE
fix(backend): fix `/quiz/questions` endpoint doc bb-437

### DIFF
--- a/apps/backend/src/modules/quiz/quiz.controller.ts
+++ b/apps/backend/src/modules/quiz/quiz.controller.ts
@@ -285,19 +285,18 @@ class QuizController extends BaseController {
 	 * @swagger
 	 * /quiz/questions:
 	 *   get:
+	 *     tags: [quiz]
 	 *     summary: Get quiz questions
 	 *     security:
 	 *       - bearerAuth: []
 	 *     parameters:
 	 *       - in: query
 	 *         name: categoryIds
+	 *         required: false  # Optional parameter
+	 *         description: Array of category IDs to filter the quiz questions (optional)
 	 *         schema:
 	 *           type: string
-	 *           items:
-	 *             type: string
-	 *         description: Array of category IDs to filter the quiz questions (optional)
-	 *         required: false  # Optional parameter
-	 *         example: [3, 6]
+	 *         example: "[3, 6]"
 	 *     responses:
 	 *       200:
 	 *         description: Successful operation


### PR DESCRIPTION
This PR will fix the `/quiz/questions` endpoint documentation.

Issues:

- The endpoint doc is not in the quiz group.
- Queries param doc are invalid.

## Issue Screenshots

![Screenshot (412)](https://github.com/user-attachments/assets/1d5cffdb-fee7-40c6-8756-e436142c16a8)

## PR Screenshots

![Screenshot (411)](https://github.com/user-attachments/assets/396cf7c6-6dd4-4fe6-8d9a-f688fba4fea4)