### PR TITLE
fix(frontend): different text alignment in onboarding questions bb-493

### DIFF
--- a/apps/frontend/src/libs/components/input/styles.module.css
+++ b/apps/frontend/src/libs/components/input/styles.module.css
@@ -52,6 +52,7 @@
 	font-size: 16px;
 	font-weight: 500;
 	line-height: 22px;
+	text-align: left;
 	cursor: pointer;
 	border: 1px solid var(--light-gray);
 	border-radius: 5px;
@@ -114,5 +115,6 @@
 		justify-content: center;
 		width: 100%;
 		max-width: 312px;
+		text-align: center;
 	}
 }


### PR DESCRIPTION
## Summary
#493 Fixed text alignment for onboarding questions.
## Screenshot
![image](https://github.com/user-attachments/assets/1c4b7e85-97cc-4d0d-a50d-1f2a415b737b)
