### PR TITLE
chore(frontend): Adjust sign-out confirmation msg bb-477

### DIFF
--- a/apps/frontend/src/libs/components/popup/libs/constants/constants.ts
+++ b/apps/frontend/src/libs/components/popup/libs/constants/constants.ts
@@ -1,0 +1,3 @@
+const NEWLINE_CHARACTER = "\n";
+
+export { NEWLINE_CHARACTER };

--- a/apps/frontend/src/libs/components/popup/popup.tsx
+++ b/apps/frontend/src/libs/components/popup/popup.tsx
@@ -1,5 +1,4 @@
 import { Button } from "~/libs/components/components.js";
-import { NumericalValue } from "~/libs/enums/enums.js";
 
 import styles from "./styles.module.css";
 
@@ -34,17 +33,13 @@ const Popup: React.FC<Properties> = ({
 						</div>
 					)}
 					<div className={styles["contents"]}>
-						{multilineTitles.length > NumericalValue.ZERO ? (
-							multilineTitles.map((line, index) => {
-								return (
-									<h1 className={styles["title"]} key={index}>
-										{line}
-									</h1>
-								);
-							})
-						) : (
-							<h1 className={styles["title"]}>{title}</h1>
-						)}
+						{multilineTitles.map((line, index) => {
+							return (
+								<h1 className={styles["title"]} key={index}>
+									{line}
+								</h1>
+							);
+						})}
 						<div className={styles["buttons-content"]}>
 							<Button label={closeButtonLabel} onClick={onClose} />
 							<Button

--- a/apps/frontend/src/libs/components/popup/popup.tsx
+++ b/apps/frontend/src/libs/components/popup/popup.tsx
@@ -1,4 +1,5 @@
 import { Button } from "~/libs/components/components.js";
+import { NumericalValue } from "~/libs/enums/enums.js";
 
 import styles from "./styles.module.css";
 
@@ -21,6 +22,8 @@ const Popup: React.FC<Properties> = ({
 	onConfirm,
 	title,
 }: Properties) => {
+	const multilineTitles: string[] = title.split("\n");
+
 	return (
 		<dialog className={styles["logout-dialog"]} open={isOpen}>
 			<div className={styles["popup-container"]}>
@@ -31,7 +34,17 @@ const Popup: React.FC<Properties> = ({
 						</div>
 					)}
 					<div className={styles["contents"]}>
-						<h1 className={styles["title"]}>{title}</h1>
+						{multilineTitles.length > NumericalValue.ZERO ? (
+							multilineTitles.map((line, index) => {
+								return (
+									<h1 className={styles["title"]} key={index}>
+										{line}
+									</h1>
+								);
+							})
+						) : (
+							<h1 className={styles["title"]}>{title}</h1>
+						)}
 						<div className={styles["buttons-content"]}>
 							<Button label={closeButtonLabel} onClick={onClose} />
 							<Button

--- a/apps/frontend/src/libs/components/popup/popup.tsx
+++ b/apps/frontend/src/libs/components/popup/popup.tsx
@@ -1,5 +1,6 @@
 import { Button } from "~/libs/components/components.js";
 
+import { NEWLINE_CHARACTER } from "./libs/constants/constants.js";
 import styles from "./styles.module.css";
 
 type Properties = {
@@ -21,7 +22,7 @@ const Popup: React.FC<Properties> = ({
 	onConfirm,
 	title,
 }: Properties) => {
-	const multilineTitles: string[] = title.split("\n");
+	const multilineTitles: string[] = title.split(NEWLINE_CHARACTER);
 
 	return (
 		<dialog className={styles["logout-dialog"]} open={isOpen}>

--- a/apps/frontend/src/libs/components/popup/styles.module.css
+++ b/apps/frontend/src/libs/components/popup/styles.module.css
@@ -22,6 +22,7 @@
 	gap: 32px;
 	align-items: center;
 	padding: 40px 60px;
+	text-align: center;
 	background-color: white;
 	border-radius: 35px;
 }

--- a/apps/frontend/src/libs/enums/popup-message.enum.ts
+++ b/apps/frontend/src/libs/enums/popup-message.enum.ts
@@ -1,5 +1,6 @@
 const PopupMessage = {
-	LOGOUT_CONFIRM: "Are you sure you want to exit?",
+	LOGOUT_CONFIRM:
+		"Oh no! You're one step away from life balance\nAre you sure you want to leave?",
 } as const;
 
 export { PopupMessage };

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 			}
 		},
 		"apps/backend": {
-			"version": "1.22.0",
+			"version": "1.23.0",
 			"dependencies": {
 				"@aws-sdk/client-s3": "3.637.0",
 				"@fastify/multipart": "8.3.0",
@@ -90,7 +90,7 @@
 			}
 		},
 		"apps/frontend": {
-			"version": "1.39.0",
+			"version": "1.40.0",
 			"dependencies": {
 				"@hookform/resolvers": "3.9.0",
 				"@reduxjs/toolkit": "2.2.7",
@@ -19998,7 +19998,7 @@
 			}
 		},
 		"packages/shared": {
-			"version": "1.22.0",
+			"version": "1.23.0",
 			"dependencies": {
 				"date-fns": "3.6.0",
 				"zod": "3.23.8"


### PR DESCRIPTION
Related to issue #477, this PR will update the Sign Out Confirmation Message.

![Screenshot (423)](https://github.com/user-attachments/assets/ded2ed22-3a27-4db8-9f61-31249f179235)
