### PR TITLE
fix(backend): update updatedAt for scores, onboarding and quiz answers bb-533

### DIFF
--- a/apps/backend/src/modules/categories/category.model.ts
+++ b/apps/backend/src/modules/categories/category.model.ts
@@ -8,6 +8,7 @@ import {
 import { TaskModel } from "../tasks/tasks.js";
 import { UserModel } from "../users/users.js";
 import { type CategoryEntity } from "./category.entity.js";
+import { ScoreModel } from "./score.model.js";
 
 class CategoryModel extends AbstractModel {
 	public name!: string;
@@ -22,6 +23,7 @@ class CategoryModel extends AbstractModel {
 					through: {
 						extra: ["score"],
 						from: `${DatabaseTableName.QUIZ_SCORES}.categoryId`,
+						modelClass: ScoreModel,
 						to: `${DatabaseTableName.QUIZ_SCORES}.userId`,
 					},
 					to: `${DatabaseTableName.USERS}.id`,

--- a/apps/backend/src/modules/categories/category.repository.ts
+++ b/apps/backend/src/modules/categories/category.repository.ts
@@ -5,10 +5,10 @@ import { type Repository } from "~/libs/types/types.js";
 import { CategoryEntity } from "./category.entity.js";
 import { type CategoryModel } from "./category.model.js";
 import {
-	type CategoryScoreModel,
 	type CategoryUpdateRequestDto,
 	type QuizScoreDto,
 } from "./libs/types/types.js";
+import { type ScoreModel } from "./score.model.js";
 
 class CategoryRepository implements Repository {
 	private categoryModel: typeof CategoryModel;
@@ -50,7 +50,7 @@ class CategoryRepository implements Repository {
 			.castTo<CategoryModel>();
 
 		await category
-			.$relatedQuery<CategoryScoreModel>(RelationName.SCORES)
+			.$relatedQuery<ScoreModel>(RelationName.SCORES)
 			.relate({ id: userId, score });
 
 		return await this.categoryModel
@@ -123,19 +123,27 @@ class CategoryRepository implements Repository {
 			.query()
 			.from(DatabaseTableName.QUIZ_SCORES)
 			.findOne({ userId })
-			.castTo<CategoryScoreModel | null>();
+			.castTo<null | ScoreModel>();
 
-		return scoreModel
-			? CategoryEntity.initialize({
-					createdAt: scoreModel.createdAt,
-					id: scoreModel.id,
-					name: scoreModel.name,
-					score: scoreModel.score,
-					scores: [],
-					updatedAt: scoreModel.updatedAt,
-					userId: scoreModel.userId,
-				})
-			: null;
+		if (!scoreModel) {
+			return null;
+		}
+
+		const { name: categoryName } = await this.categoryModel
+			.query()
+			.findById(scoreModel.categoryId)
+			.select("name")
+			.castTo<CategoryModel>();
+
+		return CategoryEntity.initialize({
+			createdAt: scoreModel.createdAt,
+			id: scoreModel.id,
+			name: categoryName,
+			score: scoreModel.score,
+			scores: [],
+			updatedAt: scoreModel.updatedAt,
+			userId: scoreModel.userId,
+		});
 	}
 
 	public async findUserScores(userId: number): Promise<CategoryEntity[]> {
@@ -148,10 +156,19 @@ class CategoryRepository implements Repository {
 					.from(DatabaseTableName.QUIZ_SCORES)
 					.where({ categoryId: category.id, userId })
 					.returning("*")
-					.castTo<CategoryScoreModel[]>();
+					.castTo<ScoreModel[]>();
 
 				const scoreEntities = scoresModel.map((score) => {
-					return CategoryEntity.initialize(score);
+					return CategoryEntity.initialize({
+						categoryId: category.id,
+						createdAt: score.createdAt,
+						id: score.id,
+						name: category.name,
+						score: score.score,
+						scores: [],
+						updatedAt: score.updatedAt,
+						userId: score.userId,
+					});
 				});
 
 				return CategoryEntity.initialize({
@@ -198,7 +215,7 @@ class CategoryRepository implements Repository {
 			.castTo<CategoryModel>();
 
 		await categoryModel
-			.$relatedQuery<CategoryScoreModel>(RelationName.SCORES)
+			.$relatedQuery<ScoreModel>(RelationName.SCORES)
 			.where({ userId })
 			.patch({ score });
 
@@ -206,7 +223,7 @@ class CategoryRepository implements Repository {
 			.query()
 			.from(DatabaseTableName.QUIZ_SCORES)
 			.findOne({ categoryId, userId })
-			.castTo<CategoryScoreModel>();
+			.castTo<ScoreModel>();
 
 		return CategoryEntity.initialize({
 			categoryId: categoryModel.id,

--- a/apps/backend/src/modules/categories/category.repository.ts
+++ b/apps/backend/src/modules/categories/category.repository.ts
@@ -129,7 +129,7 @@ class CategoryRepository implements Repository {
 			return null;
 		}
 
-		const { name: categoryName } = await this.categoryModel
+		const { name } = await this.categoryModel
 			.query()
 			.findById(scoreModel.categoryId)
 			.select("name")
@@ -138,7 +138,7 @@ class CategoryRepository implements Repository {
 		return CategoryEntity.initialize({
 			createdAt: scoreModel.createdAt,
 			id: scoreModel.id,
-			name: categoryName,
+			name,
 			score: scoreModel.score,
 			scores: [],
 			updatedAt: scoreModel.updatedAt,

--- a/apps/backend/src/modules/categories/category.repository.ts
+++ b/apps/backend/src/modules/categories/category.repository.ts
@@ -123,7 +123,7 @@ class CategoryRepository implements Repository {
 			.query()
 			.from(DatabaseTableName.QUIZ_SCORES)
 			.findOne({ userId })
-			.castTo<null | ScoreModel>();
+			.castTo<ScoreModel | undefined>();
 
 		if (!scoreModel) {
 			return null;

--- a/apps/backend/src/modules/categories/libs/types/category-score-model.type.ts
+++ b/apps/backend/src/modules/categories/libs/types/category-score-model.type.ts
@@ -1,8 +1,0 @@
-import { type CategoryModel } from "../../category.model.js";
-
-type CategoryScoreModel = {
-	score: number;
-	userId: number;
-} & CategoryModel;
-
-export { type CategoryScoreModel };

--- a/apps/backend/src/modules/categories/libs/types/types.ts
+++ b/apps/backend/src/modules/categories/libs/types/types.ts
@@ -1,4 +1,3 @@
-export { type CategoryScoreModel } from "./category-score-model.type.js";
 export { type QuizScoreRequestDto } from "./quiz-score-request-dto.type.js";
 export {
 	type CategoriesGetAllResponseDto,

--- a/apps/backend/src/modules/categories/score.model.ts
+++ b/apps/backend/src/modules/categories/score.model.ts
@@ -1,0 +1,18 @@
+import {
+	AbstractModel,
+	DatabaseTableName,
+} from "~/libs/modules/database/database.js";
+
+class ScoreModel extends AbstractModel {
+	public categoryId!: number;
+
+	public score!: number;
+
+	public userId!: number;
+
+	public static override get tableName(): string {
+		return DatabaseTableName.QUIZ_SCORES;
+	}
+}
+
+export { ScoreModel };

--- a/apps/backend/src/modules/onboarding/onboarding-answer.model.ts
+++ b/apps/backend/src/modules/onboarding/onboarding-answer.model.ts
@@ -7,6 +7,7 @@ import {
 
 import { UserModel } from "../users/users.js";
 import { OnboardingQuestionModel } from "./onboarding-question.model.js";
+import { OnboardingUserAnswerModel } from "./onboarding-user-answer.model.js";
 
 class OnboardingAnswerModel extends AbstractModel {
 	public label!: string;
@@ -32,6 +33,7 @@ class OnboardingAnswerModel extends AbstractModel {
 					from: `${DatabaseTableName.ONBOARDING_ANSWERS}.id`,
 					through: {
 						from: `${DatabaseTableName.ONBOARDING_ANSWERS_TO_USERS}.answerId`,
+						modelClass: OnboardingUserAnswerModel,
 						to: `${DatabaseTableName.ONBOARDING_ANSWERS_TO_USERS}.userId`,
 					},
 					to: `${DatabaseTableName.USERS}.id`,

--- a/apps/backend/src/modules/onboarding/onboarding-user-answer.model.ts
+++ b/apps/backend/src/modules/onboarding/onboarding-user-answer.model.ts
@@ -1,0 +1,16 @@
+import {
+	AbstractModel,
+	DatabaseTableName,
+} from "~/libs/modules/database/database.js";
+
+class OnboardingUserAnswerModel extends AbstractModel {
+	public answerId!: number;
+
+	public userId!: number;
+
+	public static override get tableName(): string {
+		return DatabaseTableName.ONBOARDING_ANSWERS_TO_USERS;
+	}
+}
+
+export { OnboardingUserAnswerModel };

--- a/apps/backend/src/modules/quiz-answers/quiz-answer.model.ts
+++ b/apps/backend/src/modules/quiz-answers/quiz-answer.model.ts
@@ -8,6 +8,7 @@ import {
 import { QuizQuestionModel } from "../quiz-questions/quiz-question.model.js";
 import { UserModel } from "../users/users.js";
 import { type QuizAnswerEntity } from "./quiz-answer.entity.js";
+import { QuizUserAnswerModel } from "./quiz-user-answer.model.js";
 
 class QuizAnswerModel extends AbstractModel {
 	public label!: string;
@@ -33,6 +34,7 @@ class QuizAnswerModel extends AbstractModel {
 					from: `${DatabaseTableName.QUIZ_ANSWERS}.id`,
 					through: {
 						from: `${DatabaseTableName.QUIZ_ANSWERS_TO_USERS}.answerId`,
+						modelClass: QuizUserAnswerModel,
 						to: `${DatabaseTableName.QUIZ_ANSWERS_TO_USERS}.userId`,
 					},
 					to: `${DatabaseTableName.USERS}.id`,

--- a/apps/backend/src/modules/quiz-answers/quiz-user-answer.model.ts
+++ b/apps/backend/src/modules/quiz-answers/quiz-user-answer.model.ts
@@ -1,0 +1,16 @@
+import {
+	AbstractModel,
+	DatabaseTableName,
+} from "~/libs/modules/database/database.js";
+
+class QuizUserAnswerModel extends AbstractModel {
+	public answerId!: number;
+
+	public userId!: number;
+
+	public static override get tableName(): string {
+		return DatabaseTableName.QUIZ_ANSWERS_TO_USERS;
+	}
+}
+
+export { QuizUserAnswerModel };


### PR DESCRIPTION
#533
- [x] add classModels to many-to-many relations
- [x] replace CategoryScoreModel with actual ScoreModel;

#### Results
✅hours in UTC, 
✅minutes match with actual minutes,
✅ all endpoints where CategoryScoreModel type replaced with ScoreModel work correctly (POST /quiz/answer, PATCH /quiz/score, GET  /quiz/score)

Correct updatedAt for scores demo (GET /quiz/score on newly created scores, then PATCH /quiz/score):
https://github.com/user-attachments/assets/edc512a7-430c-40fa-b886-b1b102525529