### PR TITLE
feat: update text on "And the last step" screen bb-537

### DIFF
--- a/apps/mobile/src/screens/notification-questions/libs/components/notification-task-days/notification-task-days.tsx
+++ b/apps/mobile/src/screens/notification-questions/libs/components/notification-task-days/notification-task-days.tsx
@@ -34,7 +34,8 @@ const NotificationTaskDays: React.FC<
 				Which days would you like to receive tasks?
 			</Text>
 			<Text style={globalStyles.mb16}>
-				Choose at least 3 days in order to achieve your life balance
+				Quick tip: we recommend selecting at least 3 days in order to achieve
+				your life balance
 			</Text>
 			<View style={[globalStyles.gap16, globalStyles.mb24]}>
 				<MultipleCheckboxInput


### PR DESCRIPTION
#537

### Overview
Adjusted "And the last step" screen:
Changed the phrase below the question "Which days would you like to receive tasks" to the phrase **"Quick tip: we recommend selecting at least 3 days in order to achieve your life balance"**

### Screenshots
<img src="https://github.com/user-attachments/assets/47c2489c-4bd7-474a-8017-c44debc38da5"  alt="the last step questions screen" width="300" />
