### PR TITLE
fix(mobile): User's avatar should have a circular form bb-603

### DIFF
--- a/apps/mobile/src/libs/components/user-avatar/user-avatar.tsx
+++ b/apps/mobile/src/libs/components/user-avatar/user-avatar.tsx
@@ -6,7 +6,7 @@ import { type UserDto } from "~/packages/users/users";
 
 type Properties = {
 	size?: number;
-	user: null | UserDto;
+	user?: null | UserDto;
 };
 
 const DEFAULT_SIZE = 34;
@@ -24,7 +24,7 @@ const UserAvatar: React.FC<Properties> = ({ size = DEFAULT_SIZE, user }) => {
 		<>
 			{user?.avatarUrl ? (
 				<Image
-					resizeMode="contain"
+					resizeMode="cover"
 					source={{ uri: user.avatarUrl }}
 					style={avatarStyle}
 				/>

--- a/apps/mobile/src/libs/components/user-avatar/user-avatar.tsx
+++ b/apps/mobile/src/libs/components/user-avatar/user-avatar.tsx
@@ -6,7 +6,7 @@ import { type UserDto } from "~/packages/users/users";
 
 type Properties = {
 	size?: number;
-	user?: null | UserDto;
+	user: null | UserDto;
 };
 
 const DEFAULT_SIZE = 34;


### PR DESCRIPTION
The avatar displayed for the user has a circular shape.


<img width="396" alt="Screenshot 2024-09-27 at 11 32 22" src="https://github.com/user-attachments/assets/9adef191-bdcb-49a7-a6c9-330dc4e5ef7c">
