### PR TITLE
fix(mobile): App occasionally closes unexpectedly after quiz analysis for new user or retake quiz for existing user bb-606

### DIFF
--- a/apps/mobile/src/navigations/questions-stack/questions-stack.tsx
+++ b/apps/mobile/src/navigations/questions-stack/questions-stack.tsx
@@ -28,7 +28,7 @@ const QuestionsStack: React.FC = () => {
 
 	return (
 		<NativeStack.Navigator screenOptions={{ headerShown: false }}>
-			{!hasAnsweredOnboardingQuestions && (
+			{!hasAnsweredOnboardingQuestions && !isRetakingQuiz && (
 				<>
 					<NativeStack.Screen
 						component={Introduction}

--- a/apps/mobile/src/navigations/questions-stack/questions-stack.tsx
+++ b/apps/mobile/src/navigations/questions-stack/questions-stack.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import { NumericalValue, QuestionsStackName } from "~/libs/enums/enums";
 import { useAppSelector } from "~/libs/hooks/hooks";
 import { type QuestionsStackNavigationParameterList } from "~/libs/types/types";
-import { BottomTabsNavigator } from "~/navigations/bottom-tabs-navigator/bottom-tabs-navigator";
 import { Introduction } from "~/screens/introduction/introduction";
 import { NotificationQuestions } from "~/screens/notification-questions/notification-questions";
 import { Onboarding } from "~/screens/onboarding/onboarding";
@@ -62,10 +61,6 @@ const QuestionsStack: React.FC = () => {
 			<NativeStack.Screen
 				component={WheelLoading}
 				name={QuestionsStackName.WHEEL_LOADING}
-			/>
-			<NativeStack.Screen
-				component={BottomTabsNavigator}
-				name={QuestionsStackName.BOTTOM_TABS}
 			/>
 		</NativeStack.Navigator>
 	);

--- a/apps/mobile/src/navigations/root/libs/hooks/use-conditional-screens.hook.ts
+++ b/apps/mobile/src/navigations/root/libs/hooks/use-conditional-screens.hook.ts
@@ -21,7 +21,7 @@ const useConditionalScreens = (): NavigationItem[] => {
 			{
 				component: BottomTabsNavigator,
 				name: RootScreenName.BOTTOM_TABS_NAVIGATOR,
-				shouldBeRendered: hasUser && hasAnsweredQuizQuestions,
+				shouldBeRendered: hasUser,
 			},
 			{
 				component: Auth,

--- a/apps/mobile/src/screens/chat/libs/components/initial-chat-message/initial-chat-message.tsx
+++ b/apps/mobile/src/screens/chat/libs/components/initial-chat-message/initial-chat-message.tsx
@@ -1,12 +1,6 @@
-import { useFocusEffect } from "@react-navigation/native";
-
 import { ChatMessage, View, Wheel } from "~/libs/components/components";
 import { transformScoresToWheelData } from "~/libs/helpers/helpers";
-import {
-	useAppDispatch,
-	useAppSelector,
-	useCallback,
-} from "~/libs/hooks/hooks";
+import { useAppDispatch, useAppSelector, useEffect } from "~/libs/hooks/hooks";
 import { globalStyles } from "~/libs/styles/styles";
 import { actions as quizActions } from "~/slices/quiz/quiz";
 
@@ -21,11 +15,9 @@ const InitialChatMessage: React.FC = () => {
 
 	const userName = user?.name ?? "";
 
-	useFocusEffect(
-		useCallback(() => {
-			void dispatch(quizActions.getScores());
-		}, [dispatch]),
-	);
+	useEffect(() => {
+		void dispatch(quizActions.getScores());
+	}, [dispatch]);
 
 	return (
 		<>

--- a/apps/mobile/src/screens/wheel-loading/wheel-loading.tsx
+++ b/apps/mobile/src/screens/wheel-loading/wheel-loading.tsx
@@ -45,7 +45,7 @@ const WheelLoading: React.FC = () => {
 		if (percentLoading === LoadingSetting.MAX_PERCENT) {
 			navigation.navigate(QuestionsStackName.BOTTOM_TABS);
 		}
-	}, [percentLoading]);
+	}, [percentLoading, navigation]);
 
 	return (
 		<BackgroundWrapper planetLayout="wheelLoading">

--- a/apps/mobile/src/screens/wheel-loading/wheel-loading.tsx
+++ b/apps/mobile/src/screens/wheel-loading/wheel-loading.tsx
@@ -7,12 +7,12 @@ import {
 	View,
 	WheelLoader,
 } from "~/libs/components/components";
-import { BaseColor, QuestionsStackName } from "~/libs/enums/enums";
+import { BaseColor, RootScreenName } from "~/libs/enums/enums";
 import { useEffect, useNavigation, useState } from "~/libs/hooks/hooks";
 import { globalStyles } from "~/libs/styles/styles";
 import {
 	type NativeStackNavigationProp,
-	type QuestionsStackNavigationParameterList,
+	type RootNavigationParameterList,
 } from "~/libs/types/types";
 
 import { LoadingSetting } from "./libs/enums";
@@ -21,9 +21,7 @@ const ANIMATION_CYCLE_DURATION = 1000;
 
 const WheelLoading: React.FC = () => {
 	const navigation =
-		useNavigation<
-			NativeStackNavigationProp<QuestionsStackNavigationParameterList>
-		>();
+		useNavigation<NativeStackNavigationProp<RootNavigationParameterList>>();
 	const [percentLoading, setPercentLoading] = useState<number>(
 		LoadingSetting.INITIAL_PERCENT,
 	);
@@ -43,7 +41,7 @@ const WheelLoading: React.FC = () => {
 
 	useEffect(() => {
 		if (percentLoading === LoadingSetting.MAX_PERCENT) {
-			navigation.navigate(QuestionsStackName.BOTTOM_TABS);
+			navigation.navigate(RootScreenName.BOTTOM_TABS_NAVIGATOR);
 		}
 	}, [percentLoading, navigation]);
 

--- a/apps/mobile/src/screens/wheel-loading/wheel-loading.tsx
+++ b/apps/mobile/src/screens/wheel-loading/wheel-loading.tsx
@@ -38,10 +38,14 @@ const WheelLoading: React.FC = () => {
 						LoadingSetting.PROCESSING_TIME_FINISH;
 				setPercentLoading(nextPercentLoading);
 			}, LoadingSetting.PROCESSING_STAGE_LENGTH);
-		} else {
+		}
+	}, [percentLoading]);
+
+	useEffect(() => {
+		if (percentLoading === LoadingSetting.MAX_PERCENT) {
 			navigation.navigate(QuestionsStackName.BOTTOM_TABS);
 		}
-	}, [navigation, percentLoading]);
+	}, [percentLoading]);
 
 	return (
 		<BackgroundWrapper planetLayout="wheelLoading">

--- a/apps/mobile/src/screens/wheel/wheel.tsx
+++ b/apps/mobile/src/screens/wheel/wheel.tsx
@@ -1,5 +1,4 @@
 import { type BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
-import { useFocusEffect } from "@react-navigation/native";
 import React from "react";
 
 import {
@@ -52,11 +51,9 @@ const Wheel: React.FC = () => {
 		navigation.navigate(BottomTabScreenName.EDIT_WHEEL_RESULTS);
 	}, [navigation]);
 
-	useFocusEffect(
-		useCallback(() => {
-			void dispatch(quizActions.getScores());
-		}, [dispatch]),
-	);
+	useEffect(() => {
+		void dispatch(quizActions.getScores());
+	}, [dispatch]);
 
 	useEffect(() => {
 		setWheelData(transformScoresToWheelData(scores));


### PR DESCRIPTION
- add separate useEffect for WheelLoading;
- add additional check for isRetakingQuiz for correct redirection when clicking retake quiz (sometimes redirect to start of the app);
- change useFocusEffect to useEffect for Wheel that sometimes crash App;

 
[retake_quiz.webm](https://github.com/user-attachments/assets/8085268c-d658-43e9-81ad-345d77ee42b0)

[hook for wheel.webm](https://github.com/user-attachments/assets/84eb97c0-1ae7-4213-8801-f4f8c24324fe)
