### PR TITLE
fix(mobile): mobile UI issues bb-619

### DIFF
--- a/apps/mobile/src/screens/chat/chat.tsx
+++ b/apps/mobile/src/screens/chat/chat.tsx
@@ -55,7 +55,7 @@ const Chat: React.FC = () => {
 
 	return (
 		<ScreenWrapper
-			edges={["left", "right"]}
+			edges={["left", "right", "bottom"]}
 			style={[globalStyles.flex1, styles.container]}
 		>
 			<View

--- a/apps/mobile/src/screens/notification-questions/notification-questions.tsx
+++ b/apps/mobile/src/screens/notification-questions/notification-questions.tsx
@@ -121,7 +121,7 @@ const NotificationQuestions: React.FC = () => {
 						<View>
 							<Text
 								size="xl"
-								style={[globalStyles.mb48, globalStyles.mt12, styles.title]}
+								style={[globalStyles.mb24, globalStyles.mt12, styles.title]}
 								weight="bold"
 							>
 								And the last step

--- a/apps/mobile/src/screens/settings/settings.tsx
+++ b/apps/mobile/src/screens/settings/settings.tsx
@@ -101,7 +101,7 @@ const Settings: React.FC = () => {
 		<ScreenWrapper edges={["top"]}>
 			<ScrollView contentContainerStyle={globalStyles.flex1}>
 				<View style={[globalStyles.flex1, globalStyles.p16, styles.container]}>
-					<Text preset="heading" style={globalStyles.mb24} weight="bold">
+					<Text preset="subheading" style={globalStyles.mb24} weight="bold">
 						Settings
 					</Text>
 					<Text preset="subheading" style={globalStyles.mb12} weight="bold">


### PR DESCRIPTION
- last quiz screen padding;
- chat screen add ScreenWrapper
edges={["left", "right", "bottom"]};
- title for Setting screen

<img width="815" alt="Screenshot 2024-09-28 at 09 36 56" src="https://github.com/user-attachments/assets/8d20cee9-1a91-40b9-8515-7a36aa215496">


<img width="396" alt="Screenshot 2024-09-28 at 09 32 35" src="https://github.com/user-attachments/assets/7ec14a5b-f557-47c6-9f45-0f0ad7df2b13">

<img width="396" alt="Screenshot 2024-09-28 at 09 29 47" src="https://github.com/user-attachments/assets/4d8c4586-2d87-4e33-a42a-b46ebf65eb04">
