### PR TITLE
fix(mobile): No saved changes in the settings after user signed up and choose task days and notification frequency bb-622

### DIFF
--- a/apps/mobile/src/navigations/bottom-tabs-navigator/bottom-tabs-navigator.tsx
+++ b/apps/mobile/src/navigations/bottom-tabs-navigator/bottom-tabs-navigator.tsx
@@ -13,10 +13,12 @@ import { BaseColor, BottomTabScreenName, DataStatus } from "~/libs/enums/enums";
 import { useAppDispatch, useAppSelector, useEffect } from "~/libs/hooks/hooks";
 import { type BottomTabNavigationParameterList } from "~/libs/types/types";
 import { WheelStackNavigator } from "~/navigations/bottom-tabs-navigator/wheel/wheel";
+import { type UserDto } from "~/packages/users/users";
 import { Chat } from "~/screens/chat/chat";
 import { Settings } from "~/screens/settings/settings";
 import { Tasks } from "~/screens/tasks/tasks";
 import { actions as appActions } from "~/slices/app/app";
+import { actions as userActions } from "~/slices/users/users";
 
 import { styles } from "./styles";
 
@@ -40,6 +42,7 @@ const screenOptions: BottomTabNavigationOptions = {
 const BottomTabsNavigator: React.FC = () => {
 	const dispatch = useAppDispatch();
 	const dataStatus = useAppSelector(({ app }) => app.dataStatus);
+	const authenticatedUser = useAppSelector(({ auth }) => auth.user);
 	const initialNotificationId = useAppSelector(
 		({ app }) => app.initialNotificationId,
 	);
@@ -51,6 +54,12 @@ const BottomTabsNavigator: React.FC = () => {
 	useEffect(() => {
 		void dispatch(appActions.updateInitialNotificationId());
 	}, [dispatch]);
+
+	useEffect(() => {
+		void dispatch(
+			userActions.getById({ id: (authenticatedUser as UserDto).id }),
+		);
+	}, [dispatch, authenticatedUser]);
 
 	if (isLoading) {
 		return null;

--- a/apps/mobile/src/screens/settings/settings.tsx
+++ b/apps/mobile/src/screens/settings/settings.tsx
@@ -42,8 +42,8 @@ const Settings: React.FC = () => {
 	const [isConfirmationModalVisible, setIsConfirmationModalVisible] =
 		useState<boolean>(false);
 
-	const user = useAppSelector((state) => state.auth.user) as UserDto;
-	const dataStatus = useAppSelector((state) => state.auth.dataStatus);
+	const user = useAppSelector((state) => state.users.user) as UserDto;
+	const dataStatus = useAppSelector((state) => state.users.dataStatus);
 
 	const { control, errors, handleSubmit, isDirty, isValid } =
 		useAppForm<NotificationQuestionsFormValues>({

--- a/apps/mobile/src/screens/tasks/tasks.tsx
+++ b/apps/mobile/src/screens/tasks/tasks.tsx
@@ -16,16 +16,13 @@ import {
 	useAppDispatch,
 	useAppSelector,
 	useCallback,
-	useEffect,
 	useFocusEffect,
 	useState,
 } from "~/libs/hooks/hooks";
 import { globalStyles } from "~/libs/styles/styles";
 import { type ImageSourcePropType } from "~/libs/types/types";
 import { type TaskDto } from "~/packages/tasks/tasks";
-import { type UserDto } from "~/packages/users/users";
 import { actions as taskActions } from "~/slices/task/task";
-import { actions as userActions } from "~/slices/users/users";
 
 import { EmptyTasksHeader } from "./libs/components/components";
 import { TaskStatus, TaskTab } from "./libs/enums/enums";
@@ -34,7 +31,6 @@ import { styles } from "./styles";
 const Tasks: React.FC = () => {
 	const dispatch = useAppDispatch();
 
-	const authenticatedUser = useAppSelector(({ auth }) => auth.user);
 	const { activeTasks, dataStatus, expiredTasks, pastTasks } = useAppSelector(
 		({ tasks }) => tasks,
 	);
@@ -43,12 +39,6 @@ const Tasks: React.FC = () => {
 
 	const hasExpiredTasks = expiredTasks.length > NumericalValue.ZERO;
 	const taskbarTasks = isCurrentMode ? activeTasks : pastTasks;
-
-	useEffect(() => {
-		void dispatch(
-			userActions.getById({ id: (authenticatedUser as UserDto).id }),
-		);
-	}, [dispatch, authenticatedUser]);
 
 	useFocusEffect(
 		useCallback(() => {


### PR DESCRIPTION
#622

### Overview

Save selected days and notification frequency in Settings after user signed up.

### Summary 

- Saved user to the state.users.user in BottomTabsNavigator
- Received user details from user slice in Settings. 

### Screenshots

<img src="https://github.com/user-attachments/assets/0b342a1b-7bcc-4236-841a-b0f6650b0459" width="300"/>
<img src="https://github.com/user-attachments/assets/57bd33e0-23fe-43b9-b271-082527e56cff" width="300"/>
<img src="https://github.com/user-attachments/assets/564bd0c8-818b-4bf0-a421-4dbc5c58a168" width="300"/>
